### PR TITLE
 Actualización de dependencias y Pipfile.lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Install pipenv
         run: |
           python -m pip install --upgrade pipenv wheel
+        - name: Update pipfile
+        run: |
+          pipenv lock  
       - name: Install dependencies
         run: |
           pipenv install --deploy --dev
-      - name: Update pipfile
-        run: |
-          pipenv lock  
       - name: Run test suite
         run: |
           pipenv run pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           pipenv install --deploy --dev
       - name: Update pipfile
         run: |
-          pipenv install --dev     
+          pipenv lock  
       - name: Run test suite
         run: |
           pipenv run pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           python -m pip install --upgrade pipenv wheel
       - name: Install dependencies
         run: |
-          pipenv install --deploy --dev
+          pipenv install --dev
       - name: Run test suite
         run: |
           pipenv run pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,12 @@ jobs:
           python -m pip install --upgrade pipenv wheel
       - name: Install dependencies
         run: |
-          pipenv install --dev
+          pipenv install --deploy --dev
+      - name: Update pipfile
+        run: |
+          pipenv install --dev     
       - name: Run test suite
         run: |
           pipenv run pytest
+
+


### PR DESCRIPTION
Se ha agregado un nuevo job a nuestro workflow de CI/CD para actualizar automáticamente el Pipfile.lock antes de ejecutar las pruebas. Esto garantiza que siempre estemos utilizando las últimas versiones de las dependencias y facilita el mantenimiento del proyecto.